### PR TITLE
add expire_metadata attribute to packagecloud_repo resource

### DIFF
--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -91,11 +91,12 @@ def install_rpm
     source 'yum.erb'
     cookbook 'packagecloud'
     mode '0644'
-    variables :base_url      => read_token(base_url).to_s,
-              :name          => filename,
-              :repo_gpgcheck => 1,
-              :description   => filename,
-              :priority      => new_resource.priority
+    variables :base_url        => read_token(base_url).to_s,
+              :name            => filename,
+              :repo_gpgcheck   => 1,
+              :description     => filename,
+              :priority        => new_resource.priority,
+              :metadata_expire => new_resource.metadata_expire
  
     notifies :run, "execute[yum-makecache-#{filename}]", :immediately
     notifies :create, "ruby_block[yum-cache-reload-#{filename}]", :immediately

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -1,8 +1,9 @@
 actions :add
 default_action :add
 
-attribute :repository,    :kind_of => String, :name_attribute => true
-attribute :master_token,  :kind_of => String
-attribute :type,          :kind_of => String, :equal_to => ['deb', 'rpm', 'gem'], :default => node['packagecloud']['default_type']
-attribute :gpg_key_url,   :kind_of => String, :default => node['packagecloud']['gpg_key_url']
-attribute :priority,      :kind_of => [Fixnum, TrueClass, FalseClass], :default => false
+attribute :repository,      :kind_of => String, :name_attribute => true
+attribute :master_token,    :kind_of => String
+attribute :type,            :kind_of => String, :equal_to => ['deb', 'rpm', 'gem'], :default => node['packagecloud']['default_type']
+attribute :gpg_key_url,     :kind_of => String, :default => node['packagecloud']['gpg_key_url']
+attribute :priority,        :kind_of => [Fixnum, TrueClass, FalseClass], :default => false
+attribute :metadata_expire, :kind_of => String, :regex => [/^\d+[d|h|m]?$/], :default => nil

--- a/templates/default/yum.erb
+++ b/templates/default/yum.erb
@@ -10,3 +10,6 @@ enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-packagecloud
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+<% if @metadata_expire %>
+metadata_expire=<%= @metadata_expire %>
+<% end %>


### PR DESCRIPTION
adds support for the `metadata_expire` config option. default is to not set one, which will use the global default.