### PR TITLE
Create new string when appending /

### DIFF
--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -210,5 +210,5 @@ def construct_uri_with_options(options)
 end
 
 def append_trailing_slash(str)
-  str.end_with?("/") ? str : str << "/"
+  str.end_with?("/") ? str : str + "/"
 end


### PR DESCRIPTION
The reason is that sometimes, you will get a default value here.
If this is the case, this value is shared with all resources of
that type. If you modify it for one, you modify it for all. This
will break in the next version of Chef because the default value
will be frozen.

See https://github.com/chef/chef/commit/705e22b975196baa6decf23f9c3a7e676d6aefc4

cc @cwebberOps