### PR TITLE
Hostname Override

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 default['packagecloud']['base_repo_path'] = "/install/repositories/"
 default['packagecloud']['gpg_key_path'] = "/gpg.key"
-default['packagecloud']['hostname'] = nil
+default['packagecloud']['_stored_hostname'] = nil
+default['packagecloud']['override_hostname'] = nil
 
 default['packagecloud']['default_type'] = value_for_platform_family(
   'debian' => 'deb',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,7 @@
 default['packagecloud']['base_repo_path'] = "/install/repositories/"
 default['packagecloud']['gpg_key_path'] = "/gpg.key"
+default['packagecloud']['hostname'] = nil
+
 default['packagecloud']['_stored_hostname'] = nil
 default['packagecloud']['override_hostname'] = nil
 


### PR DESCRIPTION
This is modified version of https://github.com/computology/packagecloud-cookbook/pull/22 which lets us keep storing the computed (or overridden) hostname to determine if read tokens should get reissued for hostname changes.