### PR TITLE
WIP: yum_resource

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,0 +1,32 @@
+---
+driver_config:
+  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  aws_ssh_key_id: <%= ENV['AWS_KEYPAIR_NAME'] %>
+  flavor_id: <%= ENV['EC2_FLAVOR_ID'] %>
+  availability_zone: <%= ENV['AWS_AVAILABILITY_ZONE'] %>
+
+provisioner:
+  name: chef_zero
+  require_chef_omnibus: latest
+
+platforms:
+- name: amazon-2014.09
+  driver_plugin: ec2
+  driver_config:
+    image_id: ami-9a6ed3f2
+    username: ec2-user
+    ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+  run_list:
+    - recipe[packagecloud_test::rpm]
+    - recipe[packagecloud_test::rubygems]
+
+- name: amazon-2015.03
+  driver_plugin: ec2
+  driver_config:
+    image_id: ami-0d4cfd66
+    username: ec2-user
+    ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+  run_list:
+    - recipe[packagecloud_test::rpm]
+    - recipe[packagecloud_test::rubygems]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,51 +7,40 @@ provisioner:
 
 platforms:
 - name: ubuntu-10.04
-  driver_config:
-    box: opscode-ubuntu-10.04
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box
   run_list:
     - recipe[packagecloud_test::lucid_deps]
     - recipe[packagecloud_test::deb]
     - recipe[packagecloud_test::rubygems_private]
 
 - name: ubuntu-12.04
-  driver_config:
-    box: opscode-ubuntu-12.04
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
   run_list:
     - recipe[packagecloud_test::precise_deps]
     - recipe[packagecloud_test::deb]
     - recipe[packagecloud_test::rubygems_private]
 
 - name: ubuntu-14.04
-  driver_config:
-    box: opscode-ubuntu-14.04
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
   run_list:
     - recipe[packagecloud_test::trusty_deps]
     - recipe[packagecloud_test::deb]
     - recipe[packagecloud_test::rubygems]
 
-- name: centos-without-epel-5.10
+- name: centos-without-epel-5.11
   run_list:
     - recipe[packagecloud_test::rpm]
     - recipe[packagecloud_test::rubygems]
 
-- name: centos-with-epel-5.10
-  driver_config:
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.10_chef-provisionerless.box
+- name: centos-with-epel-5.11
   run_list:
     - recipe[packagecloud_test::epel5]
     - recipe[packagecloud_test::rpm]
     - recipe[packagecloud_test::rubygems_private]
 
-- name: centos-6.5
+- name: centos-6.7
   run_list:
     - recipe[packagecloud_test::rpm]
     - recipe[packagecloud_test::rubygems]
 
-- name: centos-7.0
+- name: centos-7.1
   run_list:
     - recipe[packagecloud_test::rpm]
     - recipe[packagecloud_test::rubygems_private]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,9 @@
 ---
-driver_plugin: vagrant
-driver_config:
-  require_chef_omnibus: true
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
 
 platforms:
 - name: ubuntu-10.04
@@ -32,8 +34,6 @@ platforms:
     - recipe[packagecloud_test::rubygems]
 
 - name: centos-without-epel-5.10
-  driver_config:
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.10_chef-provisionerless.box
   run_list:
     - recipe[packagecloud_test::rpm]
     - recipe[packagecloud_test::rubygems]
@@ -55,23 +55,6 @@ platforms:
   run_list:
     - recipe[packagecloud_test::rpm]
     - recipe[packagecloud_test::rubygems_private]
-
-- name: amazon-2014.09
-  driver_plugin: ec2
-  driver_config:
-    image_id: ami-b5a7ea85
-    username: ec2-user
-    aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
-    aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-    aws_ssh_key_id: <%= ENV['AWS_KEYPAIR_NAME'] %>
-    ssh_key: <%= ENV['AWS_SSH_KEY_PATH'] %>
-    availability_zone: us-west-2a
-    region: us-west-2
-    flavor_id: t2.micro
-    security_group_ids: sg-598e583c
-  run_list:
-    - recipe[packagecloud_test::rpm]
-    - recipe[packagecloud_test::rubygems]
 
 suites:
 - name: default

--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -19,7 +19,7 @@ end
 
 def install_deb
   base_url = new_resource.base_url
-  repo_url = construct_uri_with_options({base_url: base_url, repo: new_resource.repository, endpoint: node['platform']})
+  repo_url = construct_uri_with_options(base_url: base_url, repo: new_resource.repository, endpoint: node['platform'])
 
   Chef::Log.debug("#{new_resource.name} deb repo url = #{repo_url}")
 
@@ -85,7 +85,7 @@ def install_rpm
 
   ruby_block 'disable repo_gpgcheck if no pygpgme' do
     block do
-      template = run_context.resource_collection.find(:template => "/etc/yum.repos.d/#{filename}.repo")
+      template = run_context.resource_collection.find(template: "/etc/yum.repos.d/#{filename}.repo")
       template.variables[:repo_gpgcheck] = 0
     end
     not_if 'rpm -qa | grep -qw pygpgme'
@@ -106,9 +106,8 @@ end
 def install_gem
   base_url = new_resource.base_url
 
-  repo_url = construct_uri_with_options({base_url: base_url, repo: new_resource.repository})
+  repo_url = construct_uri_with_options(base_url: base_url, repo: new_resource.repository)
   repo_url = read_token(repo_url, true).to_s
-
 
   execute "install packagecloud #{new_resource.name} repo as gem source" do
     command "gem source --add #{repo_url}"

--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -59,8 +59,6 @@ def install_rpm
 
   base_url_endpoint = construct_uri_with_options({base_url: base_repo_url, repo: new_resource.repository, endpoint: 'rpm_base_url'})
 
-  gpg_filename = URI.parse(base_repo_url).host.gsub!('.', '_')
-
   if new_resource.master_token
     base_url_endpoint.user     = new_resource.master_token
     base_url_endpoint.password = ''
@@ -93,10 +91,8 @@ def install_rpm
 
   yum_repository filename do
     baseurl read_token(base_url).to_s
-    gpg_filename gpg_filename
     repo_gpgcheck true
     description filename
-    priority new_resource.priority
     metadata_expire new_resource.metadata_expire
     gpgkey ::File.join(given_base_url, node['packagecloud']['gpg_key_path'])
     gpgcheck false
@@ -115,7 +111,6 @@ def install_gem
   end
 end
 
-
 def read_token(repo_url, gems=false)
   return repo_url unless new_resource.master_token
 
@@ -123,7 +118,7 @@ def read_token(repo_url, gems=false)
 
   base_repo_url = ::File.join(base_url, node['packagecloud']['base_repo_path'])
 
-  uri = construct_uri_with_options({base_url: base_repo_url, repo: new_resource.repository, endpoint: 'tokens.text'})
+  uri = construct_uri_with_options(base_url: base_repo_url, repo: new_resource.repository, endpoint: 'tokens.text')
   uri.user     = new_resource.master_token
   uri.password = ''
 


### PR DESCRIPTION
kitchen config updated and split out into cloud and vagrant configs. 
The box URLs are now assumed 

The important bit is: https://github.com/computology/packagecloud-cookbook/compare/master...damacus:yum_resource?expand=1#diff-7fff810e4deade7e7a52c03c6dfe4e5eR92

Where I've swapped out the template resource for the yum resource. It should mean this plays much nicer with anyone using the yum cookbook. 

Still working on getting this to play better with yum_proxy.

See #14 for proxy implementation. 
