### PR TITLE
Endpoint OS param needs to be platform_family

### DIFF
--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -178,7 +178,7 @@ def install_endpoint_params
           "if it cannot be automatically determined by Ohai.")
   end
 
-  { :os   => node['platform'],
+  { :os   => node['platform_family'],
     :dist => dist,
     :name => hostname }
 end


### PR DESCRIPTION
The endpoint parameters for installation needs to return the `platform_family` instead of the `platform`, otherwise other OS's are trying to hit the wrong endpoint in packagecloud.