### PR TITLE
Allow forcing of os/dist for repository install

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ packagecloud_repo "computology/packagecloud-cookbook-test-private" do
 end
 ```
 
-For forcing the os platform, supply `force_os`:
+For forcing the os and dist for repository install:
 
 ```
-packagecloud_repo "computology/packagecloud-cookbook-test-public" do
-  type "rpm"
-  force_os "rhel"
+packagecloud_repo 'computology/packagecloud-cookbook-test-public' do
+  type 'rpm'
+  force_os 'rhel'
+  force_dist '6.5'
 end
-
 ```
 
 Valid options for `type` include `deb`, `rpm`, and `gem`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ packagecloud_repo "computology/packagecloud-cookbook-test-private" do
 end
 ```
 
+For forcing the os platform, supply `force_os`:
+
+```
+packagecloud_repo "computology/packagecloud-cookbook-test-public" do
+  type "rpm"
+  force_os "rhel"
+end
+
+```
+
 Valid options for `type` include `deb`, `rpm`, and `gem`.
 
 ## Interactions with other cookbooks

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'joe@packagecloud.io'
 license 'Apache 2.0'
 description 'Installs/Configures packagecloud.io repositories.'
 long_description 'Installs/Configures packagecloud.io repositories.'
-version '0.1.0'
+version '0.1.1'
 source_url 'https://github.com/computology/packagecloud-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/computology/packagecloud-cookbook/issues' if respond_to?(:issues_url)

--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -164,7 +164,7 @@ def read_token(repo_url, gems=false)
 end
 
 def install_endpoint_params
-  dist = value_for_platform_family(
+  dist = new_resource.force_dist || value_for_platform_family(
     'debian' => node['lsb']['codename'],
     ['rhel', 'fedora'] => node['platform_version'],
   )

--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -178,9 +178,13 @@ def install_endpoint_params
           "if it cannot be automatically determined by Ohai.")
   end
 
-  { :os   => node['platform'],
+  { :os   => os_platform,
     :dist => dist,
     :name => hostname }
+end
+
+def os_platform
+  new_resource.force_os || node['platform']
 end
 
 def filename

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -3,6 +3,7 @@ default_action :add
 
 attribute :repository,      :kind_of => String, :name_attribute => true
 attribute :master_token,    :kind_of => String
+attribute :force_os,        :kind_of => String
 attribute :type,            :kind_of => String, :equal_to => ['deb', 'rpm', 'gem'], :default => node['packagecloud']['default_type']
 attribute :base_url,        :kind_of => String, :default => "https://packagecloud.io"
 attribute :gpg_key_url,     :kind_of => String, :default => node['packagecloud']['gpg_key_url']

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -4,6 +4,7 @@ default_action :add
 attribute :repository,      :kind_of => String, :name_attribute => true
 attribute :master_token,    :kind_of => String
 attribute :force_os,        :kind_of => String
+attribute :force_dist,      :kind_of => String
 attribute :type,            :kind_of => String, :equal_to => ['deb', 'rpm', 'gem'], :default => node['packagecloud']['default_type']
 attribute :base_url,        :kind_of => String, :default => "https://packagecloud.io"
 attribute :gpg_key_url,     :kind_of => String, :default => node['packagecloud']['gpg_key_url']

--- a/test/fixtures/cookbooks/packagecloud_test/recipes/rpm.rb
+++ b/test/fixtures/cookbooks/packagecloud_test/recipes/rpm.rb
@@ -13,9 +13,10 @@ end
 package 'man'
 package 'jake-docs'
 
-packagecloud_repo "computology/packagecloud-test-packages" do
-  type "rpm"
-  force_os "rhel"
+packagecloud_repo 'computology/packagecloud-test-packages' do
+  type 'rpm'
+  force_os 'rhel'
+  force_dist '6.7'
 end
 
 package 'packagecloud-test'

--- a/test/fixtures/cookbooks/packagecloud_test/recipes/rpm.rb
+++ b/test/fixtures/cookbooks/packagecloud_test/recipes/rpm.rb
@@ -12,3 +12,10 @@ end
 
 package 'man'
 package 'jake-docs'
+
+packagecloud_repo "computology/packagecloud-test-packages" do
+  type "rpm"
+  force_os "rhel"
+end
+
+package 'packagecloud-test'


### PR DESCRIPTION
Sometimes it is very useful to be able to force an specific os platform or even the distribution.
This commit enables the end user to be able to force it, here a couple examples:

```ruby
packagecloud_repo "computology/packagecloud-cookbook-test-public" do
   type "deb"
   force_os "ubuntu"
end

packagecloud_repo "computology/packagecloud-test-packages" do
   type "rpm"
   force_os "rhel"
   force_dist "6.7"
end
```