### PR TITLE
Ensure wget is installed before calling it

### DIFF
--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -23,6 +23,7 @@ def install_deb
 
   Chef::Log.debug("#{new_resource.name} deb repo url = #{repo_url}")
 
+  package 'wget'
   package 'apt-transport-https'
 
   template "/etc/apt/sources.list.d/#{filename}.list" do


### PR DESCRIPTION
This is, at best, an edge case, but some hyper-minimal systems don't
come with wget preinstalled.