### PR TITLE
Make force_os/force_dist work properly with debian repos

### DIFF
--- a/providers/repo.rb
+++ b/providers/repo.rb
@@ -31,7 +31,7 @@ end
 
 def install_deb
   base_url = new_resource.base_url
-  repo_url = construct_uri_with_options({base_url: base_url, repo: new_resource.repository, endpoint: node['platform']})
+  repo_url = construct_uri_with_options({base_url: base_url, repo: new_resource.repository, endpoint: os_platform })
 
   Chef::Log.debug("#{new_resource.name} deb repo url = #{repo_url}")
 
@@ -45,7 +45,7 @@ def install_deb
     cookbook 'packagecloud'
     mode '0644'
     variables :base_url     => repo_url.to_s,
-              :distribution => node['lsb']['codename'],
+              :distribution => dist_name,
               :component    => 'main'
 
     notifies :run, "execute[apt-key-add-#{filename}]", :immediately
@@ -172,10 +172,7 @@ def read_token(repo_url, gems=false)
 end
 
 def install_endpoint_params
-  dist = new_resource.force_dist || value_for_platform_family(
-    'debian' => node['lsb']['codename'],
-    ['rhel', 'fedora'] => node['platform_version'],
-  )
+  dist = dist_name
 
   hostname = node['packagecloud']['hostname_override'] ||
              node['fqdn'] ||
@@ -193,6 +190,13 @@ end
 
 def os_platform
   new_resource.force_os || node['platform']
+end
+
+def dist_name
+  new_resource.force_dist || value_for_platform_family(
+    'debian' => node['lsb']['codename'],
+    ['rhel', 'fedora'] => node['platform_version'],
+  )
 end
 
 def filename

--- a/test/fixtures/cookbooks/packagecloud_test/recipes/deb.rb
+++ b/test/fixtures/cookbooks/packagecloud_test/recipes/deb.rb
@@ -17,3 +17,11 @@ execute 'install_jake_source' do
   cwd '/home/vagrant'
   command 'apt-get source jake'
 end
+
+packagecloud_repo 'computology/packagecloud-test-packages' do
+  type 'deb'
+  force_os 'debian'
+  force_dist 'wheezy'
+end
+
+package 'packagecloud-test'


### PR DESCRIPTION
Fixes the issue mentioned in #40 where the force_os/force_dist options don't actually work for deb repos.

One note: in https://github.com/raintank/packagecloud-cookbook/commit/27080c1066869d564bcdc6cdeeee05d75a032774#diff-2bb89c3cb0524511e4c762ffc09cf060R21, one can see that the test installs a debian wheezy repo from `computology/packagecloud-test-packages` and installs `packagecloud-test` for debian wheezy. Since this does not actually currently exist in that repo it will fail (I had to test with a goiardi repo to make sure it worked, but it didn't seem appropriate for the PR). Someone over there will need to set that up.
