### PR TITLE
Correct expire type.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'joe@packagecloud.io'
 license 'Apache 2.0'
 description 'Installs/Configures packagecloud.io repositories.'
 long_description 'Installs/Configures packagecloud.io repositories.'
-version '0.2.1'
+version '0.2.2'
 source_url 'https://github.com/computology/packagecloud-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/computology/packagecloud-cookbook/issues' if respond_to?(:issues_url)

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -8,4 +8,4 @@ attribute :force_dist,      :kind_of => String
 attribute :type,            :kind_of => String, :equal_to => ['deb', 'rpm', 'gem'], :default => node['packagecloud']['default_type']
 attribute :base_url,        :kind_of => String, :default => "https://packagecloud.io"
 attribute :priority,        :kind_of => [Fixnum, TrueClass, FalseClass], :default => false
-attribute :metadata_expire, :kind_of => String, :regex => [/^\d+[d|h|m]?$/], :default => 300
+attribute :metadata_expire, :kind_of => Integer, :regex => [/^\d+[d|h|m]?$/], :default => 300


### PR DESCRIPTION
This is an error in Chef 13.

```
       Deprecated features used!
         Default value 300 is invalid for property metadata_expire of resource packagecloud_repo. In Chef 13 this will become an error: Option metadata_expire must be a kind of [String]!  You passed 300.. at 1 location:
           - /tmp/kitchen/cache/cookbooks/packagecloud/resources/repo.rb:11:in `class_from_file'
```