### PR TITLE
Fix expires type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ packagecloud
 ===============
 This is the Changelog for the packagecloud cookbook
 
+v0.2.3 (2016-06-1)
+-------------------
+Try to fix metadata_expire type (set as String)
+
+v0.2.2 (2016-06-1)
+-------------------
+Try to fix metadata_expire type (set as Integer)
+
 v0.2.1 (2016-05-31)
 -------------------
 Set metadata_expire option to default of 300 (5 minutes) to match the

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'joe@packagecloud.io'
 license 'Apache 2.0'
 description 'Installs/Configures packagecloud.io repositories.'
 long_description 'Installs/Configures packagecloud.io repositories.'
-version '0.2.2'
+version '0.2.3'
 source_url 'https://github.com/computology/packagecloud-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/computology/packagecloud-cookbook/issues' if respond_to?(:issues_url)

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -8,4 +8,4 @@ attribute :force_dist,      :kind_of => String
 attribute :type,            :kind_of => String, :equal_to => ['deb', 'rpm', 'gem'], :default => node['packagecloud']['default_type']
 attribute :base_url,        :kind_of => String, :default => "https://packagecloud.io"
 attribute :priority,        :kind_of => [Fixnum, TrueClass, FalseClass], :default => false
-attribute :metadata_expire, :kind_of => Integer, :regex => [/^\d+[d|h|m]?$/], :default => 300
+attribute :metadata_expire, :kind_of => String, :regex => [/^\d+[d|h|m]?$/], :default => "300"


### PR DESCRIPTION
cc @joemiller re #44 
cc @sysbot as this changes the code your PR modified (please see #44 for context)

This changes the expires type back to String and sets the default as a string "300" so that users can specify "5m" or similar strings in their configs.

Let me know what you think, and if you can, please test this and let me know how it goes.