### PR TITLE
Add basic Net::HTTP proxy support to fix helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ end
 
 Valid options for `type` include `deb`, `rpm`, and `gem`.
 
+This cookbook makes checks to determine if a package exists before installing.
+To enable proxy support *for these checks*, add the following attributes to
+your cookbook:
+
+```
+default['packagecloud']['proxy_host'] = 'myproxy.organization.com'
+default['packagecloud']['proxy_port'] = '80'
+
 ## Interactions with other cookbooks
 
 On CentOS 5, the official chef yum cookbook overwrites the file

--- a/README.md
+++ b/README.md
@@ -48,13 +48,15 @@ end
 
 Valid options for `type` include `deb`, `rpm`, and `gem`.
 
-This cookbook makes checks to determine if a package exists before installing.
-To enable proxy support *for these checks*, add the following attributes to
-your cookbook:
+This cookbook performs checks to determine if a package exists before attempting
+to install it. To enable proxy support *for these checks* (not to be confused
+with proxy support for your package manager of choice), add the following
+attributes to your cookbook:
 
 ```
 default['packagecloud']['proxy_host'] = 'myproxy.organization.com'
 default['packagecloud']['proxy_port'] = '80'
+```
 
 ## Interactions with other cookbooks
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,8 @@
 default['packagecloud']['base_repo_path'] = "/install/repositories/"
 default['packagecloud']['gpg_key_path'] = "/gpgkey"
 default['packagecloud']['hostname_override'] = nil
+default['packagecloud']['proxy_host'] = nil
+default['packagecloud']['proxy_port'] = nil
 
 default['packagecloud']['default_type'] = value_for_platform_family(
   'debian' => 'deb',

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -8,7 +8,7 @@ module PackageCloud
 
       req.basic_auth uri.user, uri.password if uri.user
 
-      http = Net::HTTP.new(uri.hostname, uri.port)
+      http = Net::HTTP.new(uri.hostname, uri.port, node['packagecloud']['proxy_host'], node['packagecloud']['proxy_port'])
       http.use_ssl = true
 
       resp = http.start { |h| h.request(req) }
@@ -27,7 +27,7 @@ module PackageCloud
 
       req.basic_auth uri.user, uri.password if uri.user
 
-      http = Net::HTTP.new(uri.hostname, uri.port)
+      http = Net::HTTP.new(uri.hostname, uri.port, node['packagecloud']['proxy_host'], node['packagecloud']['proxy_port'])
       http.use_ssl = true
 
       resp = http.start { |h|  h.request(req) }


### PR DESCRIPTION
Add basic proxy support so the `post()` and `get()` helpers will work behind a corporate proxy. Nothing changes for those not using a proxy as the default attributes are `nil`.

To use, override the following attributes in your application cookbook:

`default['packagecloud']['proxy_host'] = 'myproxy.organization.com'`
`default['packagecloud']['proxy_port'] = '80'`

Fixes #42 