### PR TITLE
Fix for users on Chef 11.10

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,8 @@ license 'Apache-2.0'
 description 'Installs/Configures packagecloud.io repositories.'
 long_description 'Installs/Configures packagecloud.io repositories.'
 version '1.0.0'
-source_url 'https://github.com/computology/packagecloud-cookbook'
-issues_url 'https://github.com/computology/packagecloud-cookbook/issues'
+source_url 'https://github.com/computology/packagecloud-cookbook' if respond_to?(:source_url)
+issues_url 'https://github.com/computology/packagecloud-cookbook/issues' if respond_to?(:issues_url)
 chef_version '>= 12.5' if respond_to?(:chef_version)
 %w(ubuntu debian redhat centos amazon oracle fedora scientific).each do |p|
   supports p


### PR DESCRIPTION
This should resolve 

ERROR: Could not read /opt/aws/opsworks/current/merged-cookbooks/packagecloud into a Chef object: undefined method `source_url'

for Chef 11.10 users