### PR TITLE
Add support for CentOS 8

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -9,6 +9,8 @@ transport:
 provisioner:
   name: dokken
   deprecations_as_errors: true
+  client_rb:
+    chef_license: accept
 
 verifier:
   name: inspec
@@ -33,6 +35,14 @@ platforms:
 - name: centos-7
   driver:
     image: dokken/centos-7
+    pid_one_command: /usr/lib/systemd/systemd
+  run_list:
+    - recipe[packagecloud_test::rpm]
+    - recipe[packagecloud_test::rubygems_private]
+
+- name: centos-8
+  driver:
+    image: dokken/centos-8
     pid_one_command: /usr/lib/systemd/systemd
   run_list:
     - recipe[packagecloud_test::rpm]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -39,6 +39,11 @@ platforms:
     - recipe[packagecloud_test::rpm]
     - recipe[packagecloud_test::rubygems_private]
 
+- name: centos-8
+  run_list:
+    - recipe[packagecloud_test::rpm]
+    - recipe[packagecloud_test::rubygems_private]
+
 - name: amazon-linux
   driver_config:
     box: mvbcoding/awslinux

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -99,25 +99,28 @@ action_class.class_eval do
 
     Chef::Log.debug("#{new_resource.name} rpm base url = #{base_url}")
 
-    package 'pygpgme' do
-      ignore_failure true
-    end
-
-    log 'pygpgme_warning' do
-      message 'The pygpgme package could not be installed. This means GPG verification is not possible for any RPM installed on your system. ' \
-              'To fix this, add a repository with pygpgme. Usualy, the EPEL repository for your system will have this. ' \
-              'More information: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F and https://github.com/opscode-cookbooks/yum-epel'
-
-      level :warn
-      not_if 'rpm -qa | grep -qw pygpgme'
-    end
-
-    ruby_block 'disable repo_gpgcheck if no pygpgme' do
-      block do
-        template = run_context.resource_collection.find(template: "/etc/yum.repos.d/#{filename}.repo")
-        template.variables[:repo_gpgcheck] = 0
+    # RHEL 8 does not include pygpgme as dnf does not require it
+    if node['platform_version'].to_i < 8
+      package 'pygpgme' do
+        ignore_failure true
       end
-      not_if 'rpm -qa | grep -qw pygpgme'
+
+      log 'pygpgme_warning' do
+        message 'The pygpgme package could not be installed. This means GPG verification is not possible for any RPM installed on your system. ' \
+                'To fix this, add a repository with pygpgme. Usualy, the EPEL repository for your system will have this. ' \
+                'More information: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F and https://github.com/opscode-cookbooks/yum-epel'
+
+        level :warn
+        not_if 'rpm -qa | grep -qw pygpgme'
+      end
+
+      ruby_block 'disable repo_gpgcheck if no pygpgme' do
+        block do
+          template = run_context.resource_collection.find(template: "/etc/yum.repos.d/#{filename}.repo")
+          template.variables[:repo_gpgcheck] = 0
+        end
+        not_if 'rpm -qa | grep -qw pygpgme'
+      end
     end
 
     gpg_url = gpg_url(new_resource.base_url, new_resource.repository, :rpm, new_resource.master_token)
@@ -146,7 +149,13 @@ action_class.class_eval do
 
     # reload internal Chef yum cache
     ruby_block "yum-cache-reload-#{filename}" do
-      block { Chef::Provider::Package::Yum::YumCache.instance.reload }
+      block do
+        if node['platform_version'].to_i >= 8
+          Chef::Provider::Package::Dnf::PythonHelper.instance.restart
+        else
+          Chef::Provider::Package::Yum::YumCache.instance.reload
+        end
+      end
       action :nothing
     end
   end


### PR DESCRIPTION
CentOS 8 switched to using dnf instead of yum so the yum-cache-reload ruby_block
needs to be updated to use
``Chef::Provider::Package::Dnf::PythonHelper.instance.restart`` on CentOS 8.

In addition, CentOS 8 removes the pygpgme as dnf does not require it so let's
not emit warnings about it on that platform.

**NOTE: This will likely fail due to the fact that the test repo does not have an el8 version of the package referenced in the tests.**

Signed-off-by: Lance Albertson <lance@osuosl.org>